### PR TITLE
Fix the delay on sending a data

### DIFF
--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -188,6 +188,14 @@ int SerialPort::Read(void* buf, int offset, int count)
 		return 0;
 	}
 #endif
+	// Check available byte count
+	DWORD dwError = 0UL;
+	COMSTAT comstat;
+	ClearCommError(hRs232c, &dwError, &comstat);
+	DWORD dwCount = comstat.cbInQue;
+	if (dwCount < count) {
+		return 0;
+	}
     // COMポートからデータ受信
     if(ReadFile(hRs232c, &recvbuf[offset], count, &dwSize, pOverlapped) == FALSE){
 #ifdef _DEBUG


### PR DESCRIPTION
When there are not enough data to be read in a receive buffer,
A directly Invoking of a ReadFile API causes to block the WriteFile process
from the another thread.
Then, it was fixed to check the available bytes to read by ClearCommError
before read.